### PR TITLE
preflight: catch Qt6PathsMissing in _check_paths() instead of crashing

### DIFF
--- a/src/scripts/preflight.py
+++ b/src/scripts/preflight.py
@@ -207,7 +207,13 @@ def _enumerate_destinations() -> list[tuple[str, Path]]:
 
 def _check_paths() -> bool:
     all_ok = True
-    for label, path in _enumerate_destinations():
+    try:
+        dests = _enumerate_destinations()
+    except Qt6PathsMissing:
+        fail("Qt6 installation paths not found — cannot verify install "
+             f"destinations. Install qmake6 with: {qt6_install_hint()}")
+        return False
+    for label, path in dests:
         reason = _validate_path(path)
         if reason is None:
             ok(f"{label}: {path}")


### PR DESCRIPTION
Closes #21

_preflight._check_paths() calls _enumerate_destinations(), which imports step modules that call qt6_plugins_dir(). If qmake6 is missing, that raises Qt6PathsMissing and currently crashes the installer with a raw traceback before preflight check 3 can report the problem cleanly.

This wraps the destination enumeration so preflight fails with a clear message and distro-specific install hint instead of aborting with a stack trace.