### PR TITLE
globalmenu: add to ALL_FEATURES so --no-globalmenu works

### DIFF
--- a/src/scripts/cli.py
+++ b/src/scripts/cli.py
@@ -27,7 +27,7 @@ from utils import have, kw_read, pkg_sync_install, run_user
 
 ALL_FEATURES = [
     "wallpapers", "fonts", "cursors", "plasma_theme", "window_decorations",
-    "kvantum", "color_schemes", "icons", "plasmoids", "acrylic_glass",
+    "kvantum", "color_schemes", "icons", "plasmoids", "globalmenu", "acrylic_glass",
     "global_theme", "layout", "sounds", "gtk", "sddm", "plymouth", "apps",
     "nautilus", "nautilus_bookmarks", "portals", "oled_care", "apply_theme",
 ]


### PR DESCRIPTION
Closes #23

`globalmenu` was missing from `ALL_FEATURES`, so it could only be toggled indirectly through the `plasmoids` shortcut in `should_process()`. That prevented users from disabling the global menu individually with `--no-globalmenu`, and `--only --globalmenu` did not work either.

This adds `globalmenu` to `ALL_FEATURES` so the CLI feature flags control it directly.