### PR TITLE
theme_switch: respect 'install' context and propagate exit code

### DIFF
--- a/src/scripts/theme_switch.py
+++ b/src/scripts/theme_switch.py
@@ -567,10 +567,9 @@ def cycle_widget_style_live(target: str) -> bool:
     return True
 
 
-def apply(mode: str) -> bool:
-    """One code path. Same behaviour whether install, service, timer, or
-    a manual `light` / `dark` / `auto` invocation runs this. Writes config
-    + extras (Kvantum, GTK, caches) + live LAF + live cursor + Kvantum
+def apply(mode: str, context: str = "user") -> bool:
+    """Writes config + extras (Kvantum, GTK, caches) + live LAF (skipped
+    during install — Plasma restarts anyway) + live cursor + Kvantum
     cycle + KWin reconfigure."""
     cursor = "MacTahoeLiquidKde-Dark" if mode == "dark" else "MacTahoeLiquidKde"
     widget = "kvantum-dark" if mode == "dark" else "kvantum"
@@ -583,7 +582,8 @@ def apply(mode: str) -> bool:
     except Exception as exc:
         print(f"theme apply: extras step failed, continuing: {exc!r}",
               file=sys.stderr)
-    _apply_lookandfeel_live(laf)
+    if context != "install":
+        _apply_lookandfeel_live(laf)
     apply_cursortheme_live(cursor)
     cycle_widget_style_live(widget)
     _qdbus("org.kde.KWin", "/KWin", "org.kde.KWin.reconfigure")
@@ -605,8 +605,8 @@ def main(argv: list[str]) -> int:
         print(USAGE, file=sys.stderr)
         return 1
 
-    apply(mode)
-    return 0
+    context = argv[1] if len(argv) > 1 else "user"
+    return 0 if apply(mode, context=context) else 1
 
 
 if __name__ == "__main__":

--- a/tests/test_theme_switch.py
+++ b/tests/test_theme_switch.py
@@ -320,7 +320,7 @@ def test_main_auto_resolves_to_time_based_mode(monkeypatch):
     calls: list = []
     monkeypatch.setattr(theme_switch, "detect_mode_by_time", lambda: "dark")
     monkeypatch.setattr(theme_switch, "apply",
-                        lambda mode: calls.append(("apply", mode)) or True)
+                        lambda mode, **kw: calls.append(("apply", mode)) or True)
     assert theme_switch.main(["auto"]) == 0
     assert calls == [("apply", "dark")]
 
@@ -333,7 +333,7 @@ def test_main_rejects_invalid_mode(monkeypatch):
     import theme_switch
     applied: list = []
     monkeypatch.setattr(theme_switch, "apply",
-                        lambda mode: applied.append(mode) or True)
+                        lambda mode, **kw: applied.append(mode) or True)
     assert theme_switch.main([]) == 1
     assert theme_switch.main(["watch"]) == 1
     assert theme_switch.main(["boot"]) == 1


### PR DESCRIPTION
Fixes two bugs with one change:

**#32 — Install context ignored.** `apply()` now accepts a `context` param (`"install"` or `"user"`). When context is `"install"`, `_apply_lookandfeel_live()` is skipped — the Plasma restart at the end of install already loads the right theme, and running both races QML teardown. `main()` reads `argv[1]` as the context and passes it through.

**#24 — Exit code always 0.** Same commit propagates `apply()` return value to `main()` exit code, so the systemd service and install step can detect failure.

Closes #32
Closes #24