### PR TITLE
launcher: fix extra gap below Suggestions in categorized mode

### DIFF
--- a/src/offline/plasmoids/org.kde.mac-tahoe-liquid-kde.launcher/contents/ui/AppsCategorized.qml
+++ b/src/offline/plasmoids/org.kde.mac-tahoe-liquid-kde.launcher/contents/ui/AppsCategorized.qml
@@ -16,7 +16,7 @@ AppListView {
 		property bool expanded: false
 
 		width: appsCategorized.availableWidth
-		height: categoryHeader.height + root.cellSizeHeight
+		height: categoryHeader.height + (grid.model.count > 0 ? root.cellSizeHeight : 0)
 		clip: true
 		spacing: 0
 
@@ -114,7 +114,7 @@ AppListView {
 			if(category.expanded) {
 				category.height = grid.expandedHeight + categoryHeader.height;
 			}else {
-				category.height = root.cellSizeHeight + categoryHeader.height;
+				category.height = (grid.model.count > 0 ? root.cellSizeHeight : 0) + categoryHeader.height;
 			}
 		}
 	}


### PR DESCRIPTION
Closes #34

In the categorized view, when Suggestions has no recent apps or documents
the grid is empty but the category still reserves root.cellSizeHeight
(~100px) of empty space below it.

The collapsed height now checks `grid.model.count > 0` — an empty
category takes only its header height.