### PR TITLE
dock, globalmenu: check if Discover is installed before pinning or showing App Store entry

### DIFF
--- a/src/offline/look-and-feel/MacTahoeLiquidKde-Dark/contents/layouts/org.kde.plasma.desktop-layout.js
+++ b/src/offline/look-and-feel/MacTahoeLiquidKde-Dark/contents/layouts/org.kde.plasma.desktop-layout.js
@@ -79,7 +79,7 @@ dock.addWidget("org.kde.plasma.marginsseparator");
 
 var tasks = dock.addWidget("org.kde.mac.tahoe.liquid.icontasks");
 tasks.currentConfigGroup = ["General"];
-tasks.writeConfig("launchers", "preferred://filemanager,preferred://terminal,preferred://browser,applications:systemsettings.desktop,applications:org.kde.discover.desktop,applications:steam.desktop");
+tasks.writeConfig("launchers", "preferred://filemanager,preferred://terminal,preferred://browser,applications:systemsettings.desktop,applications:steam.desktop");
 
 dock.addWidget("org.kde.plasma.marginsseparator");
 dock.addWidget("org.kde.mac-tahoe-liquid-kde.trashcan");

--- a/src/offline/look-and-feel/MacTahoeLiquidKde-Light/contents/layouts/org.kde.plasma.desktop-layout.js
+++ b/src/offline/look-and-feel/MacTahoeLiquidKde-Light/contents/layouts/org.kde.plasma.desktop-layout.js
@@ -79,7 +79,7 @@ dock.addWidget("org.kde.plasma.marginsseparator");
 
 var tasks = dock.addWidget("org.kde.mac.tahoe.liquid.icontasks");
 tasks.currentConfigGroup = ["General"];
-tasks.writeConfig("launchers", "preferred://filemanager,preferred://terminal,preferred://browser,applications:systemsettings.desktop,applications:org.kde.discover.desktop,applications:steam.desktop");
+tasks.writeConfig("launchers", "preferred://filemanager,preferred://terminal,preferred://browser,applications:systemsettings.desktop,applications:steam.desktop");
 
 dock.addWidget("org.kde.plasma.marginsseparator");
 dock.addWidget("org.kde.mac-tahoe-liquid-kde.trashcan");

--- a/src/offline/plasmoids/org.kde.mac.tahoe.liquid.globalmenu/appmenuapplet.cpp
+++ b/src/offline/plasmoids/org.kde.mac.tahoe.liquid.globalmenu/appmenuapplet.cpp
@@ -17,6 +17,7 @@
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QScreen>
+#include <QStandardPaths>
 #include <QTimer>
 #include <abstracttasksmodel.h>
 
@@ -405,8 +406,10 @@ void AppMenuApplet::triggerSystemMenu(QQuickItem* ctx)
 
     menu->addAction(icon("iconSystemSettings", QStringLiteral("preferences-system")), QStringLiteral("System Settings\u2026"),
         []() { runCommand(QStringLiteral("systemsettings")); });
-    menu->addAction(icon("iconAppStore", QStringLiteral("software-store-symbolic")), QStringLiteral("App Store\u2026"),
-        []() { runCommand(QStringLiteral("plasma-discover")); });
+    if (!QStandardPaths::findExecutable(QStringLiteral("plasma-discover")).isEmpty()) {
+        menu->addAction(icon("iconAppStore", QStringLiteral("software-store-symbolic")), QStringLiteral("App Store\u2026"),
+            []() { runCommand(QStringLiteral("plasma-discover")); });
+    }
 
     menu->addSeparator();
 

--- a/src/scripts/steps/layout.py
+++ b/src/scripts/steps/layout.py
@@ -11,6 +11,7 @@ from utils import qdbus_cmd, run_user
 
 LAYOUT_SCRIPT = offline("layouts/mac-tahoe.js")
 LAYOUT_RESET = offline("layouts/default.js")
+_DISCOVER_DESKTOP = "applications:org.kde.discover.desktop"
 COLORIZER_ID = "luisbocanegra.panel.colorizer"
 COLORIZER_RELEASE_URL = (
     "https://github.com/luisbocanegra/plasma-panel-colorizer/"
@@ -111,8 +112,20 @@ def _evaluate_layout_script(script: str) -> bool:
     return False
 
 
+def _discover_is_installed() -> bool:
+    """Check if org.kde.discover.desktop exists in any XDG applications dir."""
+    for prefix in (HOME / ".local/share", Path("/usr/local/share"), Path("/usr/share")):
+        if (prefix / "applications/org.kde.discover.desktop").is_file():
+            return True
+    return False
+
+
 def _evaluate_layout(script_path) -> bool:
-    return _evaluate_layout_script(script_path.read_text())
+    script = script_path.read_text()
+    if not _discover_is_installed():
+        script = script.replace(_DISCOVER_DESKTOP + ",", "")
+        script = script.replace("," + _DISCOVER_DESKTOP, "")
+    return _evaluate_layout_script(script)
 
 
 def _capture_pinned_launchers() -> list[str]:


### PR DESCRIPTION
## Summary

- **layout.py**: strip `applications:org.kde.discover.desktop` from the launchers string before evaluating the layout script when Discover is not installed on the target system
- **appmenuapplet.cpp**: guard the "App Store…" QAction with `QStandardPaths::findExecutable("plasma-discover")` — the menu entry is only added when the binary is on PATH
- **Look-and-feel layouts** (Light + Dark): remove Discover from the static launchers list to prevent theme switching from reintroducing stale launchers

## Test plan

- Run `./install` on a system without `plasma-discover` — the dock should not show a broken Discover icon
- Run `./install` on a system with `plasma-discover` — Discover should appear in the dock as before
- Click "App Store…" in the Apple menu on a system without Discover — nothing should happen (no crash, no error)
- Click "App Store…" on a system with Discover — it should open normally
- Run `mac-tahoe-theme-switch light/dark` and verify the dock does not regain a stale Discover entry

## Related issue

Closes #40
