### PR TITLE
fix(plymouth): draw LUKS2 password prompt on encrypted installs

### DIFF
--- a/src/offline/plymouth/MacTahoeLiquidKde/MacTahoeLiquidKde.script
+++ b/src/offline/plymouth/MacTahoeLiquidKde/MacTahoeLiquidKde.script
@@ -103,6 +103,11 @@ message_y       = 10;
 message_sprites = [];
 message_count   = 0;
 
+# Password prompt sprite (LUKS2 / cryptsetup). NULL until the first
+# SetDisplayPasswordFunction call draws it; reused via SetImage so a
+# shorter mask on backspace leaves no ghost pixels on the black bg.
+pw_sprite       = NULL;
+
 fun on_show_message(text)
 {
   rendered = Image.Text(text, 1, 1, 1);
@@ -124,3 +129,26 @@ fun on_hide_message(text)
   }
 }
 Plymouth.SetHideMessageFunction(on_hide_message);
+
+# ── password prompt (LUKS2 / cryptsetup) ─────────────────────────────
+# Plymouth calls this on every keystroke while a passphrase is requested.
+# Without it the script plugin's handler stays a null object and draws
+# nothing, so the user types the LUKS2 password blind (see issue #48).
+# Signature is (prompt, bullets): `bullets` is the mask length; the typed
+# text is NOT passed, so we render `bullets` ASCII asterisks.
+
+fun on_password(prompt, bullets)
+{
+  mask = "";
+  if (bullets > 0)
+    for (i = 0; i < bullets; i++)
+      mask = mask + "*";
+  img = Image.Text(prompt + " " + mask, 1, 1, 1);
+  if (pw_sprite == NULL)
+    pw_sprite = Sprite(img);
+  pw_sprite.SetImage(img);
+  pw_sprite.SetX(Window.GetX() + screen_w / 2 - img.GetWidth() / 2);
+  pw_sprite.SetY(logo.GetY() + logo_image.GetHeight() + Math.Int(screen_h * 0.10));
+  pw_sprite.SetZ(10000);
+}
+Plymouth.SetDisplayPasswordFunction(on_password);


### PR DESCRIPTION
## Summary

The MacTahoeLiquidKde Plymouth theme showed the boot logo but no password field on LUKS2-encrypted installs. The user had to type the passphrase blind; boot then proceeded to SDDM.

Root cause: the script theme wired `SetQuitFunction`, `SetBootProgressFunction` and `SetDisplayMessageFunction` but never set a password callback. In a script-based Plymouth theme the passphrase prompt is only drawn if the theme supplies that callback. Plymouth's script plugin initializes the handler to a null object (`script-lib-plymouth.c:128`) and only replaces it when the theme calls `SetDisplayPasswordFunction` (`:186`); with a null handler `display_password()` (`plugin.c:586`) draws nothing while keyboard input is still collected, so the passphrase is accepted silently.

This is verified against Plymouth upstream source and the official `themes/script/script.script` example theme. Note the public callback name is `SetDisplayPasswordFunction` (not `SetPasswordFunction`) and its signature is `(prompt, bullets)`, not `(prompt, entry, bullets)`.

## Changes

`src/offline/plymouth/MacTahoeLiquidKde/MacTahoeLiquidKde.script` (additive only):
- New global `pw_sprite = NULL;`
- New `on_password(prompt, bullets)` that renders the prompt plus a masked field of ASCII asterisks below the logo, reusing a single sprite via `SetImage` to avoid ghost pixels on backspace.
- Register it with `Plymouth.SetDisplayPasswordFunction(on_password);`

## Test plan

- [x] `tests/test_plymouth_step.py` passes (55 passed) — `_validate_theme` only checks `Image("...")` asset refs and `.plymouth` sections, so the new functions don't affect validation.
- [x] Manual: install on a LUKS2-encrypted VM, reboot, confirm the password prompt appears under the logo with a masked field that grows per keystroke.

Closes #48. Confirmed case: #47.