### PR TITLE
firefox: discover XDG native profiles

### DIFF
--- a/src/scripts/steps/firefox.py
+++ b/src/scripts/steps/firefox.py
@@ -69,6 +69,11 @@ def _theme_source() -> Path:
     return offline(THEME_SOURCE_NAME, THEME_DIRNAME)
 
 
+def _xdg_config_home() -> Path:
+    configured = os.environ.get("XDG_CONFIG_HOME")
+    return Path(configured).expanduser() if configured else HOME / ".config"
+
+
 def _profile_id(profile: Path) -> str:
     digest = hashlib.sha256(os.fsencode(str(profile))).hexdigest()[:16]
     safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "-", profile.name).strip("-")
@@ -124,6 +129,7 @@ def _candidate_roots() -> list[Path]:
     uniform fingerprint.
     """
     roots = [
+        _xdg_config_home() / "mozilla/firefox",
         HOME / ".mozilla/firefox",
         HOME / ".librewolf",
         HOME / ".floorp",

--- a/tests/test_firefox.py
+++ b/tests/test_firefox.py
@@ -29,13 +29,19 @@ def firefox_home(tmp_path, monkeypatch, offline) -> Path:
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(firefox, "HOME", home)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(home / "xdg-config"))
     monkeypatch.setattr(
         firefox, "offline", lambda *parts: Path(offline, *parts)
     )
     return home
 
 
-def test_discovers_native_flatpak_snap_and_orphan_profiles(firefox_home):
+def test_discovers_xdg_native_flatpak_snap_and_orphan_profiles(
+    firefox_home, monkeypatch,
+):
+    xdg_native = _seed_profile(
+        firefox_home / "xdg-config/mozilla/firefox", "xdg.default"
+    )
     native = _seed_profile(firefox_home / ".mozilla/firefox", "native.default")
     flatpak = _seed_profile(
         firefox_home / ".var/app/org.mozilla.firefox/.mozilla/firefox",
@@ -50,7 +56,22 @@ def test_discovers_native_flatpak_snap_and_orphan_profiles(firefox_home):
     (orphan / "prefs.js").write_text("", encoding="utf-8")
 
     assert firefox.discover_profiles() == sorted(
-        (native.resolve(), flatpak.resolve(), orphan.resolve(), snap.resolve()),
+        (
+            xdg_native.resolve(), native.resolve(), flatpak.resolve(),
+            orphan.resolve(), snap.resolve(),
+        ),
+        key=str,
+    )
+
+    monkeypatch.delenv("XDG_CONFIG_HOME")
+    default_xdg = _seed_profile(
+        firefox_home / ".config/mozilla/firefox", "xdg.default"
+    )
+    assert firefox.discover_profiles() == sorted(
+        (
+            default_xdg.resolve(), native.resolve(), flatpak.resolve(),
+            orphan.resolve(), snap.resolve(),
+        ),
         key=str,
     )
 


### PR DESCRIPTION
## Summary

- discover native Firefox profiles under `${XDG_CONFIG_HOME:-$HOME/.config}/mozilla/firefox`
- preserve legacy native, Flatpak, Snap, and Firefox-family profile roots
- cover custom `XDG_CONFIG_HOME` and the default `$HOME/.config` fallback

Closes #66

## Tests

- `tests/test_firefox.py`: 13 passed
- full suite: 1027 passed
- read-only live probe discovers the active XDG Firefox profile