### PR TITLE
Fix Plasma application cache rebuild under sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # macOS Tahoe Liquid Theme for Plasma 6.6/6.7+
 
-[![release](https://img.shields.io/github/v/release/lestercorderomurillo/macos-tahoe-liquid-kde?label=release&color=blue)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/releases) [![tests](https://img.shields.io/badge/tests-1027_passing-brightgreen)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/actions/workflows/test.yml) [![plasma](https://img.shields.io/badge/Plasma-6.6%2B-1d99f3?logo=kde)](https://kde.org/plasma-desktop/) [![license](https://img.shields.io/badge/license-GPL--3.0-blue)](LICENSE) [![report a bug](https://img.shields.io/badge/report-a%20bug-red?logo=github)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/issues/new)
+[![release](https://img.shields.io/github/v/release/lestercorderomurillo/macos-tahoe-liquid-kde?label=release&color=blue)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/releases) [![tests](https://img.shields.io/badge/tests-1028_passing-brightgreen)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/actions/workflows/test.yml) [![plasma](https://img.shields.io/badge/Plasma-6.6%2B-1d99f3?logo=kde)](https://kde.org/plasma-desktop/) [![license](https://img.shields.io/badge/license-GPL--3.0-blue)](LICENSE) [![report a bug](https://img.shields.io/badge/report-a%20bug-red?logo=github)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/issues/new)
 
 Introducing macOS Tahoe, reimagined for Linux.
 

--- a/src/scripts/steps/apply.py
+++ b/src/scripts/steps/apply.py
@@ -292,8 +292,11 @@ def _flush_caches() -> None:
                 except OSError: pass
     # Refresh mimeinfo.cache before sycoca so kbuildsycoca6 sees every app.
     _refresh_desktop_database()
-    if have("kbuildsycoca6"):
-        _run_live(["kbuildsycoca6", "--noincremental"])
+    if have("kbuildsycoca6") and not _run_live(
+            ["kbuildsycoca6", "--noincremental"]):
+        warn("KDE application cache rebuild failed — app launchers may be "
+             "unavailable until the next successful rebuild")
+        return
     ok("Caches flushed")
 
 

--- a/src/scripts/utils.py
+++ b/src/scripts/utils.py
@@ -42,6 +42,9 @@ _DESKTOP_ENV_KEYS = frozenset({
     "WAYLAND_DISPLAY",
     "XAUTHORITY",
     "XDG_CURRENT_DESKTOP",
+    # kbuildsycoca6 uses this to select plasma-applications.menu. sudo strips
+    # it; without the prefix the rebuild succeeds but registers zero apps.
+    "XDG_MENU_PREFIX",
     "XDG_RUNTIME_DIR",
     "XDG_SESSION_TYPE",
 })

--- a/tests/test_apply_portability.py
+++ b/tests/test_apply_portability.py
@@ -65,6 +65,23 @@ def test_run_live_swallows_timeout(monkeypatch):
     assert apply._run_live(["plasma-apply-wallpaperimage", "/x"]) is False
 
 
+def test_flush_caches_warns_when_application_cache_rebuild_fails(
+        monkeypatch, tmp_path):
+    monkeypatch.setattr(apply, "HOME", tmp_path)
+    monkeypatch.setattr(apply, "have", lambda cmd: cmd == "kbuildsycoca6")
+    monkeypatch.setattr(apply, "_refresh_desktop_database", lambda: None)
+    monkeypatch.setattr(apply, "_run_live", lambda cmd: False)
+    oks = []
+    warns = []
+    monkeypatch.setattr(apply, "ok", lambda message: oks.append(message))
+    monkeypatch.setattr(apply, "warn", lambda message: warns.append(message))
+
+    apply._flush_caches()
+
+    assert "Caches flushed" not in oks
+    assert any("application cache rebuild failed" in item for item in warns)
+
+
 # ── graceful Plasma restart with hard-stop fallback ──────────────────
 
 

--- a/tests/test_openrc_scheduler.py
+++ b/tests/test_openrc_scheduler.py
@@ -242,12 +242,14 @@ def test_generic_session_env_recovers_x11_from_plasmashell(
     shell.mkdir(parents=True)
     (shell / "comm").write_text("plasmashell\n")
     (shell / "environ").write_bytes(
-        b"DISPLAY=:9\0XAUTHORITY=/tmp/xauth-test\0XDG_SESSION_TYPE=x11\0")
+        b"DISPLAY=:9\0XAUTHORITY=/tmp/xauth-test\0XDG_SESSION_TYPE=x11\0"
+        b"XDG_MENU_PREFIX=plasma-\0")
     runtime = tmp_path / "runtime"
     runtime.mkdir()
     monkeypatch.setattr(utils, "_PROC_ROOT", proc)
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime))
-    for key in ("DISPLAY", "XAUTHORITY", "XDG_SESSION_TYPE"):
+    for key in ("DISPLAY", "XAUTHORITY", "XDG_SESSION_TYPE",
+                "XDG_MENU_PREFIX"):
         monkeypatch.delenv(key, raising=False)
 
     utils.restore_desktop_session_env(os.getuid())
@@ -255,6 +257,7 @@ def test_generic_session_env_recovers_x11_from_plasmashell(
     assert os.environ["DISPLAY"] == ":9"
     assert os.environ["XAUTHORITY"] == "/tmp/xauth-test"
     assert os.environ["XDG_SESSION_TYPE"] == "x11"
+    assert os.environ["XDG_MENU_PREFIX"] == "plasma-"
 
 
 @pytest.mark.parametrize("module_name", ["oled_care", "theme_switch"])


### PR DESCRIPTION
## Summary

- restore `XDG_MENU_PREFIX` from the active `plasmashell` environment after
  sudo strips it
- prevent `kbuildsycoca6 --noincremental` from rebuilding Plasma's service
  cache against a nonexistent unprefixed application menu
- report a failed application-cache rebuild instead of unconditionally
  printing `Caches flushed`
- cover both the environment restoration and failure-reporting paths

Fixes #68.

## Root cause

The installer deletes `~/.cache/ksycoca6*` and rebuilds the cache after it has
been launched through sudo. The session restoration allowlist did not include
`XDG_MENU_PREFIX`, so `kbuildsycoca6` could not select
`/etc/xdg/menus/plasma-applications.menu`.

On the affected system the command still returned success, but the resulting
cache contained zero system desktop applications. That made Default
Applications display `Other`, prevented launcher resolution for Dolphin and
Nautilus, and caused KWin to reject Spectacle because its desktop identity
could not be resolved.

The prefix-unset reproduction generated the same 258,235-byte cache as the
broken live session. Restoring `XDG_MENU_PREFIX=plasma-` generated a
518,106-byte cache containing 589 system desktop entries.

## Validation

```text
1028 passed in 11.14s
```

`git diff --check` also passes.
