### PR TITLE
fix: cancel-race clobbers successful installs; kdeglobals revert ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # macOS Tahoe Liquid Theme for Plasma 6.6/6.7+
 
-[![release](https://img.shields.io/github/v/release/lestercorderomurillo/macos-tahoe-liquid-kde?label=release&color=blue)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/releases) [![tests](https://img.shields.io/badge/tests-1216_passing-brightgreen)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/actions/workflows/test.yml) [![plasma](https://img.shields.io/badge/Plasma-6.6%2B-1d99f3?logo=kde)](https://kde.org/plasma-desktop/) [![license](https://img.shields.io/badge/license-GPL--3.0-blue)](LICENSE) [![report a bug](https://img.shields.io/badge/report-a%20bug-red?logo=github)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/issues/new)
+[![release](https://img.shields.io/github/v/release/lestercorderomurillo/macos-tahoe-liquid-kde?label=release&color=blue)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/releases) [![tests](https://img.shields.io/badge/tests-1217_passing-brightgreen)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/actions/workflows/test.yml) [![plasma](https://img.shields.io/badge/Plasma-6.6%2B-1d99f3?logo=kde)](https://kde.org/plasma-desktop/) [![license](https://img.shields.io/badge/license-GPL--3.0-blue)](LICENSE) [![report a bug](https://img.shields.io/badge/report-a%20bug-red?logo=github)](https://github.com/lestercorderomurillo/macos-tahoe-liquid-kde/issues/new)
 
 Introducing macOS Tahoe, reimagined for Linux.
 

--- a/src/scripts/cli.py
+++ b/src/scripts/cli.py
@@ -46,9 +46,17 @@ def _cancellable_entrypoint(func):
                 # Cancellations after RunTracker starts are handled by the
                 # function's existing KeyboardInterrupt path.  This catches
                 # the earlier help/root/preflight window without a traceback.
+                # If func() already returned (result_ready), the trailing
+                # check_cancelled() above raced a cancel request that
+                # landed after the real work finished — the install
+                # already fully succeeded/failed on its own terms, so
+                # report that outcome rather than clobbering it with 130
+                # (which the GUI treats as a failure and offers to retry
+                # an already-completed, possibly destructive operation).
                 if not result_ready:
                     print("\n  Aborted.", file=sys.stderr)
-                return 130
+                    return 130
+                return result
     return wrapped
 
 

--- a/src/scripts/steps/theme_switch.py
+++ b/src/scripts/steps/theme_switch.py
@@ -281,11 +281,20 @@ def uninstall() -> None:
         fail("Theme switch removal incomplete — a previous schedule could "
              f"not be removed safely ({detail})")
 
-    kw_write("--file", "kdeglobals", "--group", "KDE",
-             "--key", "AutomaticLookAndFeel", "false")
-    kw_write("--file", "kdeglobals", "--group", "KDE",
-             "--key", "DefaultLightLookAndFeel", "--delete")
-    kw_write("--file", "kdeglobals", "--group", "KDE",
-             "--key", "DefaultDarkLookAndFeel", "--delete")
-    if cleanup_complete:
+    kdeglobals_reverted = kw_write(
+        "--file", "kdeglobals", "--group", "KDE",
+        "--key", "AutomaticLookAndFeel", "false",
+    )
+    kdeglobals_reverted &= kw_write(
+        "--file", "kdeglobals", "--group", "KDE",
+        "--key", "DefaultLightLookAndFeel", "--delete",
+    )
+    kdeglobals_reverted &= kw_write(
+        "--file", "kdeglobals", "--group", "KDE",
+        "--key", "DefaultDarkLookAndFeel", "--delete",
+    )
+    if not kdeglobals_reverted:
+        warn("kdeglobals could not be fully reverted — AutomaticLookAndFeel "
+             "or a Default*LookAndFeel override may still be set")
+    if cleanup_complete and kdeglobals_reverted:
         ok("Theme switcher removed")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,33 @@ def test_cancellable_entrypoint_does_not_print_aborted_twice(
     assert capsys.readouterr().err.count("Aborted.") == 1
 
 
+def test_cancellable_entrypoint_reports_real_result_after_success_races_cancel(
+        cli_module, monkeypatch, capsys):
+    """A cancel request that lands after func() already finished (e.g.
+    the user clicks Cancel in the instant between the install
+    completing and the decorator's post-check) must not clobber a
+    successful/failed result with 130 — the operation already ran to
+    completion on its own terms, and 130 tells the GUI to offer a
+    Retry that would needlessly re-run it."""
+    checks = {"count": 0}
+
+    def check():
+        checks["count"] += 1
+        if checks["count"] == 2:
+            raise cli_module.CancellationRequested
+
+    monkeypatch.setattr(
+        cli_module, "cancellation_scope", contextlib.nullcontext)
+    monkeypatch.setattr(cli_module, "check_cancelled", check)
+
+    @cli_module._cancellable_entrypoint
+    def finished_successfully():
+        return 0
+
+    assert finished_successfully() == 0
+    assert "Aborted." not in capsys.readouterr().err
+
+
 def test_step_runner_checks_cancellation_around_each_phase(monkeypatch):
     import step_runner
 


### PR DESCRIPTION
## Summary

Two small, unrelated fixes found while re-auditing after v0.50.1 ("harden recovery and cancellation"):

- **`cli.py` `_cancellable_entrypoint`**: the `except CancellationRequested` block always `return 130`, even when `func()` had already completed (`result_ready`). A cancel request landing in the narrow window between the install/uninstall actually finishing and the decorator's own trailing `check_cancelled()` call would discard the real result and report 130 instead. Since `installer_ui.py` treats any non-zero exit code as a failure and shows a Retry button, this could tell a user a fully successful install/uninstall "failed" and prompt them to needlessly re-run it (worst case: re-running an already-completed uninstall). The fix returns the real `result` once `func()` has completed rather than unconditionally reporting cancellation. The existing `if not result_ready:` guard already distinguished this case for the "Aborted." print — the `return 130` just wasn't following the same guard.

- **`steps/theme_switch.py` `uninstall()`**: discarded the return values of the three `kw_write()` calls that revert `kdeglobals`' `AutomaticLookAndFeel` / `DefaultLightLookAndFeel` / `DefaultDarkLookAndFeel`, and unconditionally printed "Theme switcher removed". If `kwriteconfig6` fails (missing binary, no session bus, corrupt `kdeglobals`), the user was told the uninstall fully succeeded while the auto-switch schedule keys were still live in `kdeglobals`. Now tracked and folded into the success condition, with a `warn()` on partial failure — the same "`kw_write` returns" guard the rest of the codebase (and AGENTS.md) already calls for.

## Test plan

- [x] Added a regression test for the cancellation race
  (`test_cancellable_entrypoint_reports_real_result_after_success_races_cancel`)
  that fails on the old code (asserts `0`, old code returned `130`)
- [x] Full pytest suite passing — only the 3 pre-existing,
  environment-specific failures noted in #79 remain (reproduced
  identically on a clean checkout of `dev`, unrelated to this PR)
- [x] Bumped the README tests badge for the new test