### PR TITLE
acrylic glass — reduce default blur cost

### DIFF
--- a/src/scripts/steps/acrylic_glass.py
+++ b/src/scripts/steps/acrylic_glass.py
@@ -92,7 +92,10 @@ def build() -> None:
 
 _PRESET = (
     ("BevelStrength", "0.22"), ("BlurDecorations", "true"),
-    ("BlurStrength", "5"), ("BorderWidth", "32"),
+    # Keep the shipped preset at the effect's two-pass default.  Strength 5
+    # enters the third Kawase downsample level, which can make KWin sluggish
+    # on integrated GPUs and high-resolution displays.
+    ("BlurStrength", "3.5"), ("BorderWidth", "32"),
     ("BottomCornerRadius", "22"), ("Brightness", "1.0"),
     ("Contrast", "1.0"), ("DialogCornerRadius", "14"),
     ("DockCornerRadius", "20"), ("EdgeBandFactor", "0.24"),

--- a/tests/test_acrylic_glass_cmake.py
+++ b/tests/test_acrylic_glass_cmake.py
@@ -46,7 +46,10 @@ def test_acrylic_glass_preset_fits_kcm_ranges():
     # Contributor/MR tuning is not part of the project preset.
     assert "AcrylicGlassType" not in preset
     assert "RgbDriftStrength" not in preset
-    assert preset["BlurStrength"] == "5"
+    # The install preset must not override the effect's two-pass default with
+    # strength 5, which reaches the third downsample level and can cause
+    # severe compositor lag on integrated GPUs / HiDPI outputs.
+    assert preset["BlurStrength"] == "3.5"
     assert preset["HighlightStrength"] == "0.30"
     assert preset["HighlightWidth"] == "24"
     assert preset["MagnifyGlassStrength"] == "0.03"


### PR DESCRIPTION
## Summary
- keep the Acrylic Glass install preset at blur strength 3.5
- avoid entering the third Kawase downsample level at the default setting
- add a regression assertion for the performance-safe preset

## Why
The installer was overriding the effect’s built-in 3.5 default with 5. At 5, the effect enters a third downsample level, which can make KWin noticeably sluggish on integrated GPUs and high-resolution displays. Keeping the two-pass default preserves the glass effect while reducing compositor work.

## Verification
- `PYTHONPATH=src/scripts python3` preset regression assertion
- `python3 -m compileall -q src/scripts/steps/acrylic_glass.py tests/test_acrylic_glass_cmake.py`
- `git diff --check`

`pytest` is not available in this environment, so the full suite was not run.